### PR TITLE
Update route expose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Now you can
 * Create a project in openshift : `oc new-project occli`
 * Deploy the prebuilt image : `oc new-app quay.io/jasonredhat/openshift-wetty-client`
 * Expose a route on port 8888 : 
-`oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty` 
+```sh
+oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty
+```
 
 Navigate to the exposed route and login as one of the available users. There are 60 users created in the Dockerfile with usernames: user1-user60 and password: password1-password60, respectively.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You need to be a cluster admin or have your cluster admin relax the SCC restrict
 Now you can
 * Create a project in openshift : `oc new-project occli`
 * Deploy the prebuilt image : `oc new-app quay.io/jasonredhat/openshift-wetty-client`
-* Expose a route on port 8888 : `oc expose svc/openshift-wetty-client --port 8888` 
+* Expose a route on port 8888 : `oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty` 
 
 Navigate to the exposed route and login as one of the available users. There are 60 users created in the Dockerfile with usernames: user1-user60 and password: password1-password60, respectively.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You need to be a cluster admin or have your cluster admin relax the SCC restrict
 Now you can
 * Create a project in openshift : `oc new-project occli`
 * Deploy the prebuilt image : `oc new-app quay.io/jasonredhat/openshift-wetty-client`
-* Expose a route on port 8888 : `oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty` 
+* Expose route on port 8888 : `oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty` 
 
 Navigate to the exposed route and login as one of the available users. There are 60 users created in the Dockerfile with usernames: user1-user60 and password: password1-password60, respectively.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ You need to be a cluster admin or have your cluster admin relax the SCC restrict
 Now you can
 * Create a project in openshift : `oc new-project occli`
 * Deploy the prebuilt image : `oc new-app quay.io/jasonredhat/openshift-wetty-client`
-* Expose route on port 8888 : `oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty` 
+* Expose a route on port 8888 : 
+`oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty` 
 
 Navigate to the exposed route and login as one of the available users. There are 60 users created in the Dockerfile with usernames: user1-user60 and password: password1-password60, respectively.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty
 
 Navigate to the exposed route and login as one of the available users. There are 60 users created in the Dockerfile with usernames: user1-user60 and password: password1-password60, respectively.
 
-**(Note: currently using the `latest` tag you need to postfix `/wetty` on your route)**
-
 Now in that wetty terminal login to your OpenShift cluster of choice by typing the cluster URL when prompted:
 ```sh
 Server [https://localhost:8443]: mycluster.awesomeland.com


### PR DESCRIPTION
Update the README with a route expose command that will use edge termination TLS and point to the wetty subpath.