### PR TITLE
Upgrade to RHEL 7 UBI with Node 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # bases are in registry.redhat.io
 #FROM quay.io/jasonredhat/ubi7
-FROM openshift/jenkins-slave-base-centos7
+FROM registry.access.redhat.com/ubi7/nodejs-10
 USER root
 LABEL maintainer="Jason Dudash <jdudash@redhat.com>"
 LABEL name="openshift-wetty-client" \
@@ -9,7 +9,7 @@ LABEL name="openshift-wetty-client" \
       io.k8s.description="Provides oc cli tooling in a web browser" \
       io.openshift.tags="openshift,wetty,oc,ubi7"
 
-ENV NODEJS_VERSION=8 \
+ENV NODEJS_VERSION=10 \
     NODE_ENV=production \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
@@ -17,31 +17,31 @@ ENV NODEJS_VERSION=8 \
     WETTY_USERNAME_PREFIX=user \
     WETTY_PASSWORD_PREFIX=password
 
+# Not sure why I have to do this but without it
+# npm is not found....
+ENV PATH=$PATH:/opt/rh/rh-nodejs10/root/usr/bin
+
 RUN curl -sLo /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v3/clients/3.11.104/linux/oc.tar.gz && \
     tar -xzvf /tmp/oc.tar.gz -C /tmp/ && \
     mv /tmp/oc /usr/local/bin/ && \
     rm -rf /tmp/oc.tar.gz
 RUN oc version
 
-RUN yum -y install openssh-server sshpass
+RUN yum --setopt tsflags=nodocs -y install openssh-server sshpass
+RUN rm -rf /var/cache/yum
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
-#ADD sshd_config /etc/ssh/sshd_config 
 RUN systemctl enable sshd.service
-
-RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
-RUN yum -y install nodejs make gcc*
-RUN npm install npm@latest -g
 
 # To modify default users, update the WETTY_* environment variables above
 # and automate the OpenShift cluster oc login
 RUN for ((i=1; i<=$WETTY_NUMBER_OF_USERS; i++)); do useradd -d /home/${WETTY_USERNAME_PREFIX}$i -m -s /bin/bash ${WETTY_USERNAME_PREFIX}$i && echo "${WETTY_USERNAME_PREFIX}$i:${WETTY_PASSWORD_PREFIX}$i" | chpasswd && echo "oc login -u \$(whoami) -p password\$(whoami | egrep -o '[[:digit:]]{1,}' | head -n1)" >> /home/${WETTY_USERNAME_PREFIX}$i/.bashrc; done
 
-RUN npm i -g wetty.js --unsafe-perm=true --allow-root
-ADD wetty.conf .
+RUN npm i -g wetty --unsafe-perm=true --allow-root
+#ADD wetty.conf .
 #RUN cp wetty.conf /etc/init
 
 EXPOSE 8888
 USER root
-ENTRYPOINT ["wetty", "--port", "8888", "--base", "/"]
+CMD ["wetty", "--port", "8888", "--base", "/", "--server", "0.0.0.0"]
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Now you can
 * Deploy the prebuilt image : `oc new-app quay.io/jasonredhat/openshift-wetty-client`
 * Expose a route on port 8888 : 
 ```sh
-oc create route edge --service=openshift-wetty-client --port=8888 --path /wetty
+oc create route edge --service=openshift-wetty-client --port=8888
 ```
 
 Navigate to the exposed route and login as one of the available users. There are 60 users created in the Dockerfile with usernames: user1-user60 and password: password1-password60, respectively.
@@ -24,6 +24,8 @@ Now in that wetty terminal login to your OpenShift cluster of choice by typing t
 ```sh
 Server [https://localhost:8443]: mycluster.awesomeland.com
 ```
+
+**(Note: If the username and password of the wetty user match the openshift user the previous prompt may not appear)**
 
 and run whatever commands you want:
 ```sh


### PR DESCRIPTION
Upgraded the Dockerfile to use the RHEL 7 UBI Node 10 base container.
Updated README to reflect changes

Note: I used CMD instead of ENTRY just because it seems easier to debug. No other reason and has no effect on the container running in normal operation.