### PR TITLE
Configurable oc and odo version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL name="openshift-wetty-client" \
 
 ARG OC_MAJOR_VERSION
 ARG OC_VERSION
+ARG ODO_VERSION
 
 ENV NODEJS_VERSION=10 \
     NODE_ENV=production \
@@ -20,7 +21,8 @@ ENV NODEJS_VERSION=10 \
     WETTY_USERNAME_PREFIX=user \
     WETTY_PASSWORD_PREFIX=password \
     OC_MAJOR_VERSION=${OC_MAJOR_VERSION:-3} \
-    OC_VERSION=${OC_VERSION:-3.11.157}
+    OC_VERSION=${OC_VERSION:-3.11.157} \
+    ODO_VERSION=${ODO_VERSION:-1.0.0
 
 # Not sure why I have to do this but without it
 # npm is not found....
@@ -33,6 +35,8 @@ RUN if [ $OC_MAJOR_VERSION == 3 ]; then curl -sLo /tmp/oc.tar.gz $OCP3LINK; else
     mv /tmp/oc /usr/local/bin/ && \
     rm -rf /tmp/oc.tar.gz && \
     oc version
+
+RUN if [ $OC_MAJOR_VERSION == 4 ]; then curl -sLo /usr/local/bin/odo  https://mirror.openshift.com/pub/openshift-v4/clients/odo/v${ODO_VERSION}/odo-linux-amd64; chmod 755 /usr/local/bin/odo; fi
 
 RUN yum --setopt tsflags=nodocs -y install openssh-server sshpass && \
     rm -rf /var/cache/yum && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV NODEJS_VERSION=10 \
     WETTY_PASSWORD_PREFIX=password \
     OC_MAJOR_VERSION=${OC_MAJOR_VERSION:-3} \
     OC_VERSION=${OC_VERSION:-3.11.157} \
-    ODO_VERSION=${ODO_VERSION:-1.0.0
+    ODO_VERSION=${ODO_VERSION:-1.0.0}
 
 # Not sure why I have to do this but without it
 # npm is not found....

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,29 +9,36 @@ LABEL name="openshift-wetty-client" \
       io.k8s.description="Provides oc cli tooling in a web browser" \
       io.openshift.tags="openshift,wetty,oc,ubi7"
 
+ARG OC_MAJOR_VERSION
+ARG OC_VERSION
+
 ENV NODEJS_VERSION=10 \
     NODE_ENV=production \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     WETTY_NUMBER_OF_USERS=60 \
     WETTY_USERNAME_PREFIX=user \
-    WETTY_PASSWORD_PREFIX=password
+    WETTY_PASSWORD_PREFIX=password \
+    OC_MAJOR_VERSION=${OC_MAJOR_VERSION:-3} \
+    OC_VERSION=${OC_VERSION:-3.11.157}
 
 # Not sure why I have to do this but without it
 # npm is not found....
 ENV PATH=$PATH:/opt/rh/rh-nodejs10/root/usr/bin
+ENV OCP4LINK=https://mirror.openshift.com/pub/openshift-v${OC_MAJOR_VERSION}/clients/oc/${OC_VERSION}/linux/oc.tar.gz
+ENV OCP3LINK=https://mirror.openshift.com/pub/openshift-v${OC_MAJOR_VERSION}/clients/${OC_VERSION}/linux/oc.tar.gz
 
-RUN curl -sLo /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v3/clients/3.11.104/linux/oc.tar.gz && \
+RUN if [ $OC_MAJOR_VERSION == 3 ]; then curl -sLo /tmp/oc.tar.gz $OCP3LINK; else curl -sLo /tmp/oc.tar.gz $OCP4LINK; fi && \
     tar -xzvf /tmp/oc.tar.gz -C /tmp/ && \
     mv /tmp/oc /usr/local/bin/ && \
-    rm -rf /tmp/oc.tar.gz
-RUN oc version
+    rm -rf /tmp/oc.tar.gz && \
+    oc version
 
-RUN yum --setopt tsflags=nodocs -y install openssh-server sshpass
-RUN rm -rf /var/cache/yum
-RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
-RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
-RUN systemctl enable sshd.service
+RUN yum --setopt tsflags=nodocs -y install openssh-server sshpass && \
+    rm -rf /var/cache/yum && \
+    ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' && \
+    ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N '' && \
+    systemctl enable sshd.service
 
 # To modify default users, update the WETTY_* environment variables above
 # and automate the OpenShift cluster oc login


### PR DESCRIPTION
Add support to configure the major version of oc, 3 or 4. With version 4 add support to configure the version of odo. Reduce the number of RUN lines to reduce the number of layers.

Build like:

```
buildah bud --build-arg OC_MAJOR_VERSION=3 --build-arg OC_VERSION=3.11.157 -t quay.io/danclark/openshift-wetty-client:3.11.157 -f Dockerfile .
```

```
buildah bud --build-arg OC_MAJOR_VERSION=4 --build-arg OC_VERSION=4.2 -t quay.io/danclark/openshift-wetty-client:4.2 -f Dockerfile .
```